### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy to Server
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/Spacexplorer11/Word_BAN/security/code-scanning/1](https://github.com/Spacexplorer11/Word_BAN/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. Since the workflow does not interact with repository contents or require write access, the permissions can be limited to `contents: read`. This ensures the `GITHUB_TOKEN` has minimal privileges while still allowing the workflow to function correctly.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow to explicitly define repository permissions for improved clarity and access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->